### PR TITLE
Move Last.fm-related things to new service category

### DIFF
--- a/commands/now.py
+++ b/commands/now.py
@@ -2,14 +2,6 @@ from models.command import BaseCommand
 from models.lastuser import LastUser
 from utils.parser import parser
 
-from settings import secret
-
-import pylast
-
-from pylast import User
-
-import re
-
 import logging
 import asyncio
 
@@ -21,47 +13,13 @@ class Now(BaseCommand):
 
     def __init__(self, name, parser, admin_required):
         super(Now, self).__init__(name, parser, admin_required)
-        self.network = pylast.LastFMNetwork(api_key=secret.LAST_API_KEY,
-                                            api_secret=secret.LAST_API_SECRET,
-                                            username=secret.LAST_USER,
-                                            password_hash=secret.LAST_PASS_HASH)
-
-    def get_lastfm_user(self, id):
-        try:
-            user = LastUser.get(LastUser.user_id == id)
-            return user.lastfm_user
-        except:
-            return None
-
-    def get_recent_track(self, user):
-        last_user = User(user, self.network)
-        now = last_user.get_now_playing()
-        reply = ""
-        if now is not None:
-            reply = "now playing"
-        else:
-            now = last_user.get_recent_tracks(limit=1)[0].track
-            reply = "last played"
-        (track, artist, album) = self.get_now_info(now)
-        return "{}: {} - {} - {}".format(reply, artist, album, track)
-
-    def get_now_info(self, now):
-        """ gets the current artist and track from last """
-        track = now.get_name()
-        artist = now.get_artist().get_name()
-        album = ""
-        try:
-            album = now.get_album().get_name()
-        except:
-            album = "(no album)"
-        return (track, artist, album)
 
     @asyncio.coroutine
     def run(self, bot, conversation, user, args):
         message = ""
-        lastfm_user = self.get_lastfm_user(user.id)
+        lastfm_user = self.bot.get_lastfm_user(user.id)
         if lastfm_user is not None:
-            message = self.get_recent_track(lastfm_user)
+            message = self.bot.get_recent_track(lastfm_user)
         else:
             message = "** must set username first (!reglast)**"
         yield from bot.send_message(conversation, message)

--- a/hangoutsbot.py
+++ b/hangoutsbot.py
@@ -19,6 +19,8 @@ from utils.hooks import register_hooks
 from utils.enums import EventType, ConversationType
 from utils.textutils import spacing
 
+from services.lastfm import Lastfm
+
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
@@ -36,6 +38,10 @@ class HangoutsBot(object):
         self.client = hangups.client.Client(self.login())
         self.user = User.get_or_create(id=settings.BOT_ID, defaults={'first_name': settings.BOT_FIRST_NAME, 'last_name': settings.BOT_LAST_NAME})[0]
         self.hooks = Hook.select()
+        self.lastfm = Lastfm(settings.LAST_API_KEY,
+                             settings.LAST_API_SECRET,
+                             settings.LAST_USER,
+                             settings.LAST_PASS_HASH)
 
     def login(self):
         return hangups.auth.get_auth_stdin(settings.COOKIES_FILE_PATH)

--- a/services/lastfm.py
+++ b/services/lastfm.py
@@ -1,0 +1,49 @@
+from models.lastuser import LastUser
+
+import pylast
+from pylast import User
+
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+class Lastfm(object):
+
+    def __init__(self, api_key, api_secret, username, password_hash):
+        self.network = pylast.LastFMNetwork(api_key=api_key,
+                                            api_secret=api_secret,
+                                            username=username,
+                                            password_hash=password_hash)
+
+    def get_lastfm_user(self, id):
+        try:
+            user = LastUser.get(LastUser.user_id == id)
+            return user.lastfm_user
+        except:
+            return None
+
+    def get_recent_track(self, user):
+        last_user = User(user, self.network)
+        now = last_user.get_now_playing()
+        reply = ""
+        if now is not None:
+            reply = "now playing"
+        else:
+            now = last_user.get_recent_tracks(limit=1)[0].track
+            reply = "last played"
+        (track, artist, album) = self.get_now_info(now)
+        return "{}: {} - {} - {}".format(reply, artist, album, track)
+
+    def get_now_info(self, now):
+        """ gets the current artist and track from last """
+        track = now.get_name()
+        artist = now.get_artist().get_name()
+        album = ""
+        try:
+            album = now.get_album().get_name()
+        except:
+            album = "(no album)"
+        return (track, artist, album)
+


### PR DESCRIPTION
Last.fm is now a service started when the bot starts, and available to
all commands/hooks via self.bot.lastfm. This is a refactor to support
future commands/hooks.