### PR TITLE
  Fix no gpm album

### DIFF
--- a/services/lastfm.py
+++ b/services/lastfm.py
@@ -67,7 +67,10 @@ class Lastfm(object):
         message = "{}: **{} ".format(status, artist)
         if album is None:
             track = self.bot.gmusic.get_best_song_match(artist, song)
-            album = track['album']
+            try:
+                album = track.get('album')
+            except:
+                album = '(not found)'
         message += "- {} ".format(album)
         message += "- {}**".format(song)
         if user is not None:


### PR DESCRIPTION
I made the assumption that if last.fm didn't know, the album, you could
definitely get the results from GPM, since you're listening to the music
there. However, since the hangouts bot masquerades as a separate user,
it won't know about uploaded music of a user. This can lead to GPM
searches with no album results.